### PR TITLE
[FIX] DockerTestConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ To run tests, after starting services, create a test database:
 
     docker-compose exec postgres psql -h postgres -U postgres -c "create database test_db"
 
+**NOTE**: This command will ask you for the postgres password which is defined
+in the `.env` file.
+
 and execute:
 
     docker-compose run -e "APP_SETTINGS=neurostuff.config.DockerTestConfig" --rm -w /neurostuff neurostuff python -m pytest neurostuff/tests

--- a/neurostuff/example_config.py
+++ b/neurostuff/example_config.py
@@ -40,7 +40,9 @@ class TestingConfig(Config):
 
 
 class DockerTestConfig(TestingConfig):
-    SQLALCHEMY_DATABASE_URI = 'postgres://postgres@postgres:5432/test_db'
+    POSTGRES_PASSWORD = os.environ.get('POSTGRES_PASSWORD', '')
+    SQLALCHEMY_DATABASE_URI = 'postgres://postgres:' \
+         f'{POSTGRES_PASSWORD}@postgres:5432/test_db'
 
 
 class TravisConfig(TestingConfig):

--- a/neurostuff/example_config.py
+++ b/neurostuff/example_config.py
@@ -40,9 +40,9 @@ class TestingConfig(Config):
 
 
 class DockerTestConfig(TestingConfig):
-    POSTGRES_PASSWORD = os.environ.get('POSTGRES_PASSWORD', '')
+    DB_NAME = 'test_db'
     SQLALCHEMY_DATABASE_URI = 'postgres://postgres:' \
-         f'{POSTGRES_PASSWORD}@postgres:5432/test_db'
+         f'{POSTGRES_PASSWORD}@postgres:5432/{DB_NAME}'
 
 
 class TravisConfig(TestingConfig):

--- a/neurostuff/example_config.py
+++ b/neurostuff/example_config.py
@@ -41,6 +41,7 @@ class TestingConfig(Config):
 
 class DockerTestConfig(TestingConfig):
     DB_NAME = 'test_db'
+    POSTGRES_PASSWORD = os.environ.get('POSTGRES_PASSWORD', '')
     SQLALCHEMY_DATABASE_URI = 'postgres://postgres:' \
          f'{POSTGRES_PASSWORD}@postgres:5432/{DB_NAME}'
 


### PR DESCRIPTION
fixes #14

This pull request suggests:
- change DockerTestConfig to look for the environmental variable `POSTGRES_PASSWORD`
- add a note in the readme on where to find the postgres password.