### PR TITLE
Remove initialization of database

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ Build the containers and start services using the development configuration:
 
 The server should now be running at http://localhost/
 
-Next, initialize, migrate and upgrade the database migrations.
+Next, migrate and upgrade the database migrations.
 
-    docker-compose exec neurostuff bash
-    rm -rf /migrations/migrations
-    python manage.py db init
-    python manage.py db migrate
-    python manage.py db upgrade
+    docker-compose exec neurostuff \
+    bash -c "python manage.py db stamp head && \
+    python manage.py db migrate && \
+    python manage.py db upgrade"
+    
 
 Finally, add an admin user, and ingest data
 

--- a/README.md
+++ b/README.md
@@ -27,15 +27,24 @@ The server should now be running at http://localhost/
 Next, migrate and upgrade the database migrations.
 
     docker-compose exec neurostuff \
-    bash -c "python manage.py db stamp head && \
-    python manage.py db migrate && \
-    python manage.py db upgrade"
-    
+        bash -c \
+            "python manage.py db merge heads && \
+             python manage.py db stamp head && \
+             python manage.py db migrate && \
+             python manage.py db upgrade"
+
+**Note**: `python manage.py db merge heads` is not strictly necessary
+unless you have multiple schema versions that are not from the same history
+(e.g., multiple files in the `versions` directory).
+However, `python manage.py db merge heads` makes the migration more robust
+when there are multiple versions from different histories.
 
 Finally, add an admin user, and ingest data
 
-    python manage.py add_user admin@neurostuff.org password
-    python manage.py ingest_neurosynth
+    docker-compose exec neurostuff \
+        bash -c \
+            "python manage.py add_user admin@neurostuff.org password && \
+             python manage.py ingest_neurosynth"
 
 
 ## Maintaining docker image and db

--- a/postgres/migrations/migrations/README
+++ b/postgres/migrations/migrations/README
@@ -1,1 +1,2 @@
 Generic single-database configuration.
+Generated with `python manage.py db init` from the repository root

--- a/postgres/migrations/migrations/script.py.mako
+++ b/postgres/migrations/migrations/script.py.mako
@@ -7,6 +7,7 @@ Create Date: ${create_date}
 """
 from alembic import op
 import sqlalchemy as sa
+import sqlalchemy_utils
 ${imports if imports else ""}
 
 # revision identifiers, used by Alembic.


### PR DESCRIPTION
fixes #12
fixes #13 

This pull request changes the process of how one would get started using their own computer by relying on the existing database initialization in the repo and forcing the database schema history to work locally.

Since this pull request suggests keeping `script.py.mako`, the addition of `import sqlalchemy_utils` will remain meaning there is no need to manually edit files to get started.